### PR TITLE
Add theme system with Glass jelly pieces and physics animations

### DIFF
--- a/Tim-Bak-Toe.xcodeproj/project.pbxproj
+++ b/Tim-Bak-Toe.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1F70B204DFAA67BED3662BB7 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E4A1CB71DEBFB104FA68E983 /* Foundation.framework */; };
 		AA000001AAAA000100000001 /* TimBakToeApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000001BBBB000100000001 /* TimBakToeApp.swift */; };
 		AA000002AAAA000200000002 /* Player.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000002BBBB000200000002 /* Player.swift */; };
 		AA000003AAAA000300000003 /* BoardPosition.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000003BBBB000300000003 /* BoardPosition.swift */; };
@@ -50,14 +51,31 @@
 		AA000041AAAA004100000041 /* CGExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000041BBBB004100000041 /* CGExtensions.swift */; };
 		AA000042AAAA004200000042 /* AccessibilityIdentifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000042BBBB004200000042 /* AccessibilityIdentifiers.swift */; };
 		AA000043AAAA004300000043 /* CountdownOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000043BBBB004300000043 /* CountdownOverlayView.swift */; };
+		B4BAFAAD9D45B7FC3AE7680A /* ScreenshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD5466B81043274B9976571F /* ScreenshotTests.swift */; };
 		DC1283F32477741000B1317E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DC1283F22477741000B1317E /* Assets.xcassets */; };
 		DC96D7EB2F5B861000847D50 /* EnableSwipeBack.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC96D7EA2F5B861000847D50 /* EnableSwipeBack.swift */; };
 		DC96D7F02F5BED4D00847D50 /* GameCenterManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC96D7EC2F5BED4D00847D50 /* GameCenterManager.swift */; };
 		DC96D7F12F5BED4D00847D50 /* MultiplayerAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC96D7ED2F5BED4D00847D50 /* MultiplayerAdapter.swift */; };
 		DC96D7F22F5BED4D00847D50 /* MultiplayerMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC96D7EE2F5BED4D00847D50 /* MultiplayerMessage.swift */; };
+		AA000044AAAA004400000044 /* AppTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000044BBBB004400000044 /* AppTheme.swift */; };
+		AA000045AAAA004500000045 /* ThemeProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000045BBBB004500000045 /* ThemeProvider.swift */; };
+		AA000046AAAA004600000046 /* ThemeEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000046BBBB004600000046 /* ThemeEnvironment.swift */; };
+		AA000047AAAA004700000047 /* NeumorphicTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000047BBBB004700000047 /* NeumorphicTheme.swift */; };
+		AA000048AAAA004800000048 /* GlassTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000048BBBB004800000048 /* GlassTheme.swift */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		7051849FC5E7AA1F27566B0D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = DC1283E12477740900B1317E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DC1283E82477740900B1317E;
+			remoteInfo = TimBakToe;
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXFileReference section */
+		389C6F0A07CCB50C79F32EE6 /* ScreenshotTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ScreenshotTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		BB000001BBBB000100000001 /* TimBakToeApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimBakToeApp.swift; sourceTree = "<group>"; };
 		BB000002BBBB000200000002 /* Player.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Player.swift; sourceTree = "<group>"; };
 		BB000003BBBB000300000003 /* BoardPosition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardPosition.swift; sourceTree = "<group>"; };
@@ -101,6 +119,12 @@
 		BB000041BBBB004100000041 /* CGExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CGExtensions.swift; sourceTree = "<group>"; };
 		BB000042BBBB004200000042 /* AccessibilityIdentifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityIdentifiers.swift; sourceTree = "<group>"; };
 		BB000043BBBB004300000043 /* CountdownOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountdownOverlayView.swift; sourceTree = "<group>"; };
+		BB000044BBBB004400000044 /* AppTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppTheme.swift; sourceTree = "<group>"; };
+		BB000045BBBB004500000045 /* ThemeProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeProvider.swift; sourceTree = "<group>"; };
+		BB000046BBBB004600000046 /* ThemeEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeEnvironment.swift; sourceTree = "<group>"; };
+		BB000047BBBB004700000047 /* NeumorphicTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NeumorphicTheme.swift; sourceTree = "<group>"; };
+		BB000048BBBB004800000048 /* GlassTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlassTheme.swift; sourceTree = "<group>"; };
+		BD5466B81043274B9976571F /* ScreenshotTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ScreenshotTests.swift; path = ScreenshotTests.swift; sourceTree = "<group>"; };
 		DC1283E92477740900B1317E /* TimBakToe.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TimBakToe.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		DC1283F22477741000B1317E /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		DC96D7EA2F5B861000847D50 /* EnableSwipeBack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnableSwipeBack.swift; sourceTree = "<group>"; };
@@ -108,9 +132,18 @@
 		DC96D7ED2F5BED4D00847D50 /* MultiplayerAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiplayerAdapter.swift; sourceTree = "<group>"; };
 		DC96D7EE2F5BED4D00847D50 /* MultiplayerMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiplayerMessage.swift; sourceTree = "<group>"; };
 		DC96D7F32F5BED8D00847D50 /* TimBakToe.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = TimBakToe.entitlements; sourceTree = "<group>"; };
+		E4A1CB71DEBFB104FA68E983 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		9C0AEB636D575843CF633131 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1F70B204DFAA67BED3662BB7 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		DC1283E62477740900B1317E /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -121,6 +154,31 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		0AD4E549BEE67814B885AC40 /* ScreenshotTests */ = {
+			isa = PBXGroup;
+			children = (
+				BD5466B81043274B9976571F /* ScreenshotTests.swift */,
+			);
+			name = ScreenshotTests;
+			path = ScreenshotTests;
+			sourceTree = "<group>";
+		};
+		85FA42AF52853F1D36D4FFC9 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				A31E6A7F7B31123A4031CC0C /* iOS */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		A31E6A7F7B31123A4031CC0C /* iOS */ = {
+			isa = PBXGroup;
+			children = (
+				E4A1CB71DEBFB104FA68E983 /* Foundation.framework */,
+			);
+			name = iOS;
+			sourceTree = "<group>";
+		};
 		CC000001CCCC000100000001 /* Core */ = {
 			isa = PBXGroup;
 			children = (
@@ -236,11 +294,24 @@
 				BB000031BBBB003100000031 /* Theme.swift */,
 				BB000032BBBB003200000032 /* PieceStyle.swift */,
 				BB000033BBBB003300000033 /* PieceViewState.swift */,
+				BB000044BBBB004400000044 /* AppTheme.swift */,
+				BB000045BBBB004500000045 /* ThemeProvider.swift */,
+				BB000046BBBB004600000046 /* ThemeEnvironment.swift */,
 				CC000021CCCC002100000021 /* Shapes */,
 				CC000022CCCC002200000022 /* Components */,
 				CC000023CCCC002300000023 /* Layout */,
+				CC000024CCCC002400000024 /* Themes */,
 			);
 			path = DesignSystem;
+			sourceTree = "<group>";
+		};
+		CC000024CCCC002400000024 /* Themes */ = {
+			isa = PBXGroup;
+			children = (
+				BB000047BBBB004700000047 /* NeumorphicTheme.swift */,
+				BB000048BBBB004800000048 /* GlassTheme.swift */,
+			);
+			path = Themes;
 			sourceTree = "<group>";
 		};
 		CC000021CCCC002100000021 /* Shapes */ = {
@@ -287,6 +358,8 @@
 				DC96D7F32F5BED8D00847D50 /* TimBakToe.entitlements */,
 				DC1283EB2477740900B1317E /* Tim-Bak-Toe */,
 				DC1283EA2477740900B1317E /* Products */,
+				85FA42AF52853F1D36D4FFC9 /* Frameworks */,
+				0AD4E549BEE67814B885AC40 /* ScreenshotTests */,
 			);
 			sourceTree = "<group>";
 		};
@@ -294,6 +367,7 @@
 			isa = PBXGroup;
 			children = (
 				DC1283E92477740900B1317E /* TimBakToe.app */,
+				389C6F0A07CCB50C79F32EE6 /* ScreenshotTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -324,6 +398,24 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		0E162309B903EDCEA568D08A /* ScreenshotTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4FD9345EF3E852312A0F7B3C /* Build configuration list for PBXNativeTarget "ScreenshotTests" */;
+			buildPhases = (
+				98CBB2D4B394DA597BF9D962 /* Sources */,
+				9C0AEB636D575843CF633131 /* Frameworks */,
+				790730CA94C925B9C0728776 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				7E25613068CE95CB484FA08A /* PBXTargetDependency */,
+			);
+			name = ScreenshotTests;
+			productName = ScreenshotTests;
+			productReference = 389C6F0A07CCB50C79F32EE6 /* ScreenshotTests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
 		DC1283E82477740900B1317E /* TimBakToe */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = DC1283FD2477741000B1317E /* Build configuration list for PBXNativeTarget "TimBakToe" */;
@@ -370,11 +462,19 @@
 			projectRoot = "";
 			targets = (
 				DC1283E82477740900B1317E /* TimBakToe */,
+				0E162309B903EDCEA568D08A /* ScreenshotTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		790730CA94C925B9C0728776 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		DC1283E72477740900B1317E /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -386,6 +486,14 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		98CBB2D4B394DA597BF9D962 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B4BAFAAD9D45B7FC3AE7680A /* ScreenshotTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		DC1283E52477740900B1317E /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -437,12 +545,63 @@
 				AA000040AAAA004000000040 /* Animation+TimingCurves.swift in Sources */,
 				AA000041AAAA004100000041 /* CGExtensions.swift in Sources */,
 				AA000042AAAA004200000042 /* AccessibilityIdentifiers.swift in Sources */,
+				AA000044AAAA004400000044 /* AppTheme.swift in Sources */,
+				AA000045AAAA004500000045 /* ThemeProvider.swift in Sources */,
+				AA000046AAAA004600000046 /* ThemeEnvironment.swift in Sources */,
+				AA000047AAAA004700000047 /* NeumorphicTheme.swift in Sources */,
+				AA000048AAAA004800000048 /* GlassTheme.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
+/* Begin PBXTargetDependency section */
+		7E25613068CE95CB484FA08A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = TimBakToe;
+			target = DC1283E82477740900B1317E /* TimBakToe */;
+			targetProxy = 7051849FC5E7AA1F27566B0D /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
 /* Begin XCBuildConfiguration section */
+		636E939745EB853394179522 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 9P7CJ3Z2B8;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
+				PRODUCT_BUNDLE_IDENTIFIER = indie.bulty.XO3.ScreenshotTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 6.0;
+				TEST_TARGET_NAME = TimBakToe;
+				VALIDATE_PRODUCT = YES;
+				WRAPPER_EXTENSION = xctest;
+			};
+			name = Release;
+		};
+		BBEED3D745E9532A574C6D7D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 9P7CJ3Z2B8;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
+				PRODUCT_BUNDLE_IDENTIFIER = indie.bulty.XO3.ScreenshotTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 6.0;
+				TEST_TARGET_NAME = TimBakToe;
+				WRAPPER_EXTENSION = xctest;
+			};
+			name = Debug;
+		};
 		DC1283FB2477741000B1317E /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -584,7 +743,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 2.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "indie.bulty.XO3";
+				PRODUCT_BUNDLE_IDENTIFIER = indie.bulty.XO3;
 				PRODUCT_NAME = TimBakToe;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				REGISTER_APP_GROUPS = YES;
@@ -625,7 +784,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 2.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "indie.bulty.XO3";
+				PRODUCT_BUNDLE_IDENTIFIER = indie.bulty.XO3;
 				PRODUCT_NAME = TimBakToe;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				REGISTER_APP_GROUPS = YES;
@@ -642,6 +801,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		4FD9345EF3E852312A0F7B3C /* Build configuration list for PBXNativeTarget "ScreenshotTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				636E939745EB853394179522 /* Release */,
+				BBEED3D745E9532A574C6D7D /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		DC1283E42477740900B1317E /* Build configuration list for PBXProject "Tim-Bak-Toe" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Tim-Bak-Toe/DesignSystem/AppTheme.swift
+++ b/Tim-Bak-Toe/DesignSystem/AppTheme.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+
+enum AppTheme: String, CaseIterable, Codable {
+    case neumorphic = "Neumorphic"
+    case glass = "Glass"
+
+    static let defaultTheme: AppTheme = .neumorphic
+
+    var displayName: String { rawValue }
+
+    var provider: any ThemeProvider {
+        switch self {
+        case .neumorphic: return NeumorphicTheme()
+        case .glass: return GlassTheme()
+        }
+    }
+}

--- a/Tim-Bak-Toe/DesignSystem/ThemeEnvironment.swift
+++ b/Tim-Bak-Toe/DesignSystem/ThemeEnvironment.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+private struct ThemeProviderKey: EnvironmentKey {
+    static let defaultValue: any ThemeProvider = NeumorphicTheme()
+}
+
+extension EnvironmentValues {
+    var themeProvider: any ThemeProvider {
+        get { self[ThemeProviderKey.self] }
+        set { self[ThemeProviderKey.self] = newValue }
+    }
+}

--- a/Tim-Bak-Toe/DesignSystem/ThemeProvider.swift
+++ b/Tim-Bak-Toe/DesignSystem/ThemeProvider.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+
+protocol ThemeProvider: Sendable {
+    var backgroundColor: Color { get }
+    var overlayBackdropColor: Color { get }
+
+    func pieceBottomLayer(state: PieceViewState, size: CGSize) -> AnyView
+    func pieceUpperLayer(state: PieceViewState, size: CGSize, style: PieceStyle) -> AnyView
+    func winParticles(winner: Player?) -> AnyView
+
+    func dragSquishScale() -> CGSize
+    func dragRotation(velocityX: CGFloat) -> Double
+    func placeBounceKeyframes() -> [CGSize]
+    func wonAnimation() -> Animation
+    func wonBounceDelay(pieceIndex: Int) -> Double
+    func wonBounceOffset(for size: CGSize) -> CGFloat
+}

--- a/Tim-Bak-Toe/DesignSystem/Themes/GlassTheme.swift
+++ b/Tim-Bak-Toe/DesignSystem/Themes/GlassTheme.swift
@@ -1,0 +1,130 @@
+import SwiftUI
+
+struct GlassTheme: ThemeProvider {
+    // Deep navy background
+    var backgroundColor: Color { Color(red: 0.051, green: 0.067, blue: 0.090) }
+    var overlayBackdropColor: Color { Color.black.opacity(0.5) }
+
+    static let xColor = Color(red: 0.941, green: 0.400, blue: 0.188) // #F06630
+    static let oColor = Color(red: 0.231, green: 0.608, blue: 0.969) // #3B9BF7
+
+    static func pieceColor(for style: PieceStyle) -> Color {
+        style == .X ? xColor : oColor
+    }
+
+    func pieceBottomLayer(state: PieceViewState, size: CGSize) -> AnyView {
+        AnyView(Color.clear)
+    }
+
+    func pieceUpperLayer(state: PieceViewState, size: CGSize, style: PieceStyle) -> AnyView {
+        AnyView(JellyBubbleView(style: style, size: size))
+    }
+
+    func winParticles(winner: Player?) -> AnyView {
+        guard let winner else { return AnyView(EmptyView()) }
+        let color: Color = winner == .x ? Self.xColor : Self.oColor
+        return AnyView(JellyBurstView(playerColor: color))
+    }
+
+    // Vertical stretch: feels like pulling a sphere up out of a tight hole
+    func dragSquishScale() -> CGSize { CGSize(width: 0.88, height: 1.12) }
+
+    // Lean in the direction of horizontal movement — creates sphere-rolling-on-surface illusion
+    func dragRotation(velocityX: CGFloat) -> Double {
+        let clamped = max(-1200, min(1200, Double(velocityX)))
+        return clamped * 0.016 // max ±19.2° at ±1200 pts/s
+    }
+
+    // Just the impact flatten — the spring back is handled by PieceView with high bounce
+    func placeBounceKeyframes() -> [CGSize] {
+        [CGSize(width: 1.38, height: 0.62)]
+    }
+
+    func wonAnimation() -> Animation {
+        .spring(duration: 0.4, bounce: 0.7).repeatForever(autoreverses: true)
+    }
+
+    func wonBounceDelay(pieceIndex: Int) -> Double {
+        Double(pieceIndex) * 0.08
+    }
+
+    func wonBounceOffset(for size: CGSize) -> CGFloat {
+        -size.height * 0.3
+    }
+}
+
+private struct JellyBubbleView: View {
+    let style: PieceStyle
+    let size: CGSize
+
+    private var color: Color { GlassTheme.pieceColor(for: style) }
+
+    var body: some View {
+        ZStack {
+            // 1. Translucent jelly body
+            Circle()
+                .fill(color.opacity(0.35))
+
+            // 2. Radial inner glow (wet look)
+            Circle()
+                .fill(
+                    RadialGradient(
+                        gradient: Gradient(colors: [color.opacity(0.6), Color.clear]),
+                        center: .center,
+                        startRadius: 0,
+                        endRadius: size.width * 0.3
+                    )
+                )
+
+            // 3. Specular highlight (upper-left)
+            Ellipse()
+                .fill(Color.white.opacity(0.8))
+                .frame(width: size.width * 0.3, height: size.height * 0.18)
+                .offset(x: -size.width * 0.12, y: -size.height * 0.22)
+
+            // 4. X/O symbol with player color
+            style.overlay(forSize: size)
+                .colorMultiply(color)
+
+            // 5. Bubble rim
+            Circle()
+                .stroke(Color.white.opacity(0.3), lineWidth: 1)
+        }
+    }
+}
+
+private struct JellyBurstView: View {
+    let playerColor: Color
+
+    @State private var burst = false
+    @State private var visible = true
+
+    var body: some View {
+        ZStack {
+            if visible {
+                ForEach(0..<24, id: \.self) { i in
+                    let angle = Double(i) / 24.0 * 360.0
+                    let radians = angle * .pi / 180.0
+                    let distance: CGFloat = burst ? 180 : 0
+
+                    Capsule()
+                        .fill(playerColor.opacity(Double.random(in: 0.6...1.0)))
+                        .frame(width: 6, height: 14)
+                        .offset(
+                            x: cos(radians) * distance,
+                            y: sin(radians) * distance
+                        )
+                        .rotationEffect(.degrees(angle + 90))
+                }
+            }
+        }
+        .onAppear {
+            withAnimation(.easeOut(duration: 0.6)) {
+                burst = true
+            }
+            withAnimation(.spring().delay(0.4)) {
+                visible = false
+            }
+        }
+    }
+}

--- a/Tim-Bak-Toe/DesignSystem/Themes/NeumorphicTheme.swift
+++ b/Tim-Bak-Toe/DesignSystem/Themes/NeumorphicTheme.swift
@@ -1,0 +1,92 @@
+import SwiftUI
+
+struct NeumorphicTheme: ThemeProvider {
+    var backgroundColor: Color { Theme.Col.gameBackground }
+    var overlayBackdropColor: Color { Color.black.opacity(0.3) }
+
+    func pieceBottomLayer(state: PieceViewState, size: CGSize) -> AnyView {
+        AnyView(state.bottomShadowLayer(pieceSize: size))
+    }
+
+    func pieceUpperLayer(state: PieceViewState, size: CGSize, style: PieceStyle) -> AnyView {
+        AnyView(
+            Group {
+                state.upperFillLayer(pieceSize: size)
+                style.overlay(forSize: size)
+            }
+        )
+    }
+
+    func winParticles(winner: Player?) -> AnyView {
+        guard winner != nil else { return AnyView(EmptyView()) }
+        return AnyView(NeumorphicConfettiView())
+    }
+
+    func dragSquishScale() -> CGSize { CGSize(width: 1, height: 1) }
+    func dragRotation(velocityX: CGFloat) -> Double { 0 }
+    func placeBounceKeyframes() -> [CGSize] { [] }
+
+    func wonAnimation() -> Animation {
+        Animation.easeInOutBack.repeatForever(autoreverses: true)
+    }
+
+    func wonBounceDelay(pieceIndex: Int) -> Double { 0 }
+    func wonBounceOffset(for size: CGSize) -> CGFloat { 0 }
+}
+
+struct ConfettiParticle: Identifiable {
+    let id: Int
+    let color: Color
+    let size: CGFloat
+    var offset: CGSize
+    var opacity: Double
+}
+
+private struct NeumorphicConfettiView: View {
+    @State private var particles: [ConfettiParticle] = []
+
+    var body: some View {
+        ForEach(particles) { particle in
+            Circle()
+                .fill(particle.color)
+                .frame(width: particle.size, height: particle.size)
+                .offset(particle.offset)
+                .opacity(particle.opacity)
+        }
+        .onAppear { spawnConfetti() }
+    }
+
+    private func spawnConfetti() {
+        let colors: [Color] = [
+            Theme.Col.redStart, Theme.Col.redEnd,
+            Theme.Col.blueStart, Theme.Col.blueEnd,
+            Theme.Col.greenStart, Theme.Col.greenEnd,
+            .yellow, .purple, .orange
+        ]
+
+        for i in 0..<40 {
+            particles.append(ConfettiParticle(
+                id: i,
+                color: colors.randomElement()!,
+                size: CGFloat.random(in: 6...14),
+                offset: .zero,
+                opacity: 1
+            ))
+        }
+
+        withAnimation(.easeOut(duration: 1.5)) {
+            for i in particles.indices {
+                particles[i].offset = CGSize(
+                    width: CGFloat.random(in: -200...200),
+                    height: CGFloat.random(in: -400...100)
+                )
+            }
+        }
+
+        withAnimation(.easeIn(duration: 0.8).delay(1.0)) {
+            for i in particles.indices {
+                particles[i].opacity = 0
+            }
+        }
+    }
+}

--- a/Tim-Bak-Toe/Features/Game/ContentView.swift
+++ b/Tim-Bak-Toe/Features/Game/ContentView.swift
@@ -62,6 +62,7 @@ struct ContentView: View {
             }
             .toolbar(.hidden, for: .navigationBar)
         }
+        .environment(\.themeProvider, settingsViewModel.appTheme.provider)
         .preferredColorScheme(settingsViewModel.preferredColorScheme)
         .onAppear {
             let isFirstLaunch = !UserDefaults.standard.bool(forKey: "AlreadyLaunched")

--- a/Tim-Bak-Toe/Features/Game/PieceView.swift
+++ b/Tim-Bak-Toe/Features/Game/PieceView.swift
@@ -4,9 +4,15 @@ struct PieceView: View {
     let pieceId: UUID
     let style: PieceStyle
     let size: CGSize
+    let pieceIndex: Int
     @Bindable var viewModel: GameViewModel
 
+    @Environment(\.themeProvider) private var theme
+
     @State private var hasAppeared = false
+    @State private var squishScale: CGSize = CGSize(width: 1, height: 1)
+    @State private var bounceOffset: CGFloat = 0
+    @State private var rotationAngle: Double = 0
 
     private var state: PieceUIState? {
         viewModel.pieceStates[pieceId]
@@ -17,13 +23,15 @@ struct PieceView: View {
         let relativeOffset = state?.relativeOffset ?? .zero
         let scale = state?.scale ?? 1.0
         ZStack {
-            viewState.bottomShadowLayer(pieceSize: size)
-            viewState.upperFillLayer(pieceSize: size)
-            style.overlay(forSize: size)
+            theme.pieceBottomLayer(state: viewState, size: size)
+            theme.pieceUpperLayer(state: viewState, size: size, style: style)
         }
         .frame(width: size.width, height: size.height)
         .scaleEffect(hasAppeared ? scale : 0.01)
+        .scaleEffect(x: squishScale.width, y: squishScale.height)
+        .rotationEffect(.degrees(rotationAngle))
         .offset(relativeOffset)
+        .offset(y: bounceOffset)
         .allowsHitTesting(viewState.allowsHitTesting)
         .onGeometryChange(for: CGPoint.self) { proxy in
             proxy.frame(in: .global).center
@@ -36,9 +44,18 @@ struct PieceView: View {
             DragGesture(coordinateSpace: .global)
                 .onChanged { drag in
                     viewModel.pieceDragChanged(pieceId, drag: drag)
+                    // Lean in direction of movement — velocity-based tilt
+                    let targetRotation = theme.dragRotation(velocityX: drag.velocity.width)
+                    withAnimation(.spring(duration: 0.12, bounce: 0.35)) {
+                        rotationAngle = targetRotation
+                    }
                 }
                 .onEnded { drag in
                     viewModel.pieceDragEnded(pieceId, drag: drag)
+                    // Spring rotation back to upright
+                    withAnimation(.spring(duration: 0.5, bounce: 0.65)) {
+                        rotationAngle = 0
+                    }
                 }
         )
         .onChange(of: viewState) { _, newState in
@@ -53,11 +70,66 @@ struct PieceView: View {
     }
 
     private func handleStateChange(_ newState: PieceViewState) {
-        let animation: Animation = newState == .won
-            ? Animation.easeInOutBack.repeatForever(autoreverses: true)
-            : .default
-        withAnimation(animation) {
-            viewModel.pieceStates[pieceId]?.scale = newState.scale
+        switch newState {
+
+        case .dragged:
+            withAnimation(.default) {
+                viewModel.pieceStates[pieceId]?.scale = newState.scale
+            }
+            let squish = theme.dragSquishScale()
+            let squishIsDistorted = squish.width != 1 || squish.height != 1
+            if squishIsDistorted {
+                // Continuous jelly wobble while held: oscillates between neutral and squish
+                withAnimation(.spring(duration: 0.32, bounce: 0.55).repeatForever(autoreverses: true)) {
+                    squishScale = squish
+                }
+            }
+
+        case .placed:
+            withAnimation(.default) {
+                viewModel.pieceStates[pieceId]?.scale = newState.scale
+            }
+            let keyframes = theme.placeBounceKeyframes()
+            if !keyframes.isEmpty {
+                // Snap to impact scale quickly (cancels the drag wobble animation)
+                withAnimation(.spring(duration: 0.07, bounce: 0)) {
+                    squishScale = keyframes[0]
+                }
+                // After the snap, spring back with high-bounce jelly physics
+                withAnimation(.spring(duration: 0.62, bounce: 0.82).delay(0.07)) {
+                    squishScale = CGSize(width: 1, height: 1)
+                }
+            } else {
+                withAnimation(.spring(duration: 0.3, bounce: 0.4)) {
+                    squishScale = CGSize(width: 1, height: 1)
+                }
+            }
+
+        case .won:
+            let delay = theme.wonBounceDelay(pieceIndex: pieceIndex)
+            withAnimation(theme.wonAnimation().delay(delay)) {
+                viewModel.pieceStates[pieceId]?.scale = newState.scale
+            }
+            let offset = theme.wonBounceOffset(for: size)
+            if offset != 0 {
+                withAnimation(.spring(duration: 0.4, bounce: 0.7).repeatForever(autoreverses: true).delay(delay)) {
+                    bounceOffset = offset
+                }
+            }
+            // Ensure squish is clean for win state
+            withAnimation(.spring(duration: 0.3, bounce: 0.5)) {
+                squishScale = CGSize(width: 1, height: 1)
+                rotationAngle = 0
+            }
+
+        default:
+            withAnimation(.spring(duration: 0.3, bounce: 0.4)) {
+                squishScale = CGSize(width: 1, height: 1)
+                rotationAngle = 0
+            }
+            withAnimation(.default) {
+                viewModel.pieceStates[pieceId]?.scale = newState.scale
+            }
         }
     }
 }

--- a/Tim-Bak-Toe/Features/Game/PiecesContainerView.swift
+++ b/Tim-Bak-Toe/Features/Game/PiecesContainerView.swift
@@ -15,9 +15,8 @@ struct PiecesContainerView: View {
         let spacing = pieceSize.height / 5.0
 
         HStack(spacing: spacing) {
-            ForEach(pieces) { piece in
-                let index = pieces.firstIndex(where: { $0.id == piece.id }) ?? 0
-                PieceView(pieceId: piece.id, style: piece.style, size: pieceSize, viewModel: viewModel)
+            ForEach(Array(pieces.enumerated()), id: \.element.id) { index, piece in
+                PieceView(pieceId: piece.id, style: piece.style, size: pieceSize, pieceIndex: index, viewModel: viewModel)
                     .setAccessibilityIdentifier(element: piece.owner == .x ? .hostPiece(index) : .peerPiece(index))
                     .zIndex(piece.zIndex)
             }

--- a/Tim-Bak-Toe/Features/Game/WinnerOverlayView.swift
+++ b/Tim-Bak-Toe/Features/Game/WinnerOverlayView.swift
@@ -119,11 +119,3 @@ struct WinnerOverlayView: View {
         }
     }
 }
-
-struct ConfettiParticle: Identifiable {
-    let id: Int
-    let color: Color
-    let size: CGFloat
-    var offset: CGSize
-    var opacity: Double
-}

--- a/Tim-Bak-Toe/Features/Settings/SettingsScreen.swift
+++ b/Tim-Bak-Toe/Features/Settings/SettingsScreen.swift
@@ -34,7 +34,6 @@ struct SettingsScreen: View {
                     }
                     .pickerStyle(.segmented)
                     .controlSize(LayoutConstants.isPad ? .large : .regular)
-
                     .frame(maxWidth: LayoutConstants.isPad ? 500 : 250)
 
                     HStack {

--- a/Tim-Bak-Toe/Features/Settings/SettingsViewModel.swift
+++ b/Tim-Bak-Toe/Features/Settings/SettingsViewModel.swift
@@ -17,6 +17,10 @@ final class SettingsViewModel {
         }
     }
 
+    var appTheme: AppTheme {
+        didSet { UserDefaults.standard.set(appTheme.rawValue, forKey: "appTheme") }
+    }
+
     var preferredColorScheme: ColorScheme? {
         switch colorSchemeSetting {
         case 1: return .light
@@ -29,9 +33,12 @@ final class SettingsViewModel {
         let storedSoundOn = UserDefaults.standard.object(forKey: "soundOn") as? Bool ?? true
         let storedDuration = UserDefaults.standard.double(forKey: "timerDuration")
         let storedColorScheme = UserDefaults.standard.integer(forKey: "colorScheme")
+        let storedThemeRaw = UserDefaults.standard.string(forKey: "appTheme")
+        let storedTheme = storedThemeRaw.flatMap { AppTheme(rawValue: $0) } ?? AppTheme.defaultTheme
 
         self.soundOn = storedSoundOn
         self.timerDuration = storedDuration == 0 ? 5.0 : storedDuration
         self.colorSchemeSetting = storedColorScheme
+        self.appTheme = storedTheme
     }
 }


### PR DESCRIPTION
Introduces a ThemeProvider protocol and two themes (Neumorphic, Glass) that control how game pieces are rendered and animated.

Glass theme pieces are translucent jelly bubbles with:
- Velocity-based rotation during drag (lean into movement direction)
- Vertical stretch lift squish on pickup (pulling-sphere-from-hole feel)
- Continuous spring wobble while held
- Instant impact flatten + high-bounce spring settle on placement
- Staggered Y-bounce win animation

Infrastructure:
- AppTheme enum (defaulting to .neumorphic) persisted via UserDefaults
- ThemeProvider protocol injected via SwiftUI environment key
- NeumorphicTheme lifts existing rendering unchanged
- SettingsViewModel gains appTheme property for future theme picker